### PR TITLE
Upgrade to PHP 7.0.19 base image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 
 env:
-  - VERSION=0.3.3 VARIANT=php70 LATEST=yes
+  - VERSION=0.3.4 VARIANT=php70 LATEST=yes
 
 before_script:
   - env | sort

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM php:7.0.17-fpm-alpine
+FROM php:7.0.19-fpm-alpine
 
 # see http://label-schema.org/rc1/
 LABEL org.label-schema.name="spryker-base" \


### PR DESCRIPTION
7.0.19 fixes the issue with enhanced stream URLs. So the predis bug is gone.