### PR TITLE
adapt shop skeleton to ignore other propel configs than from config/Shared/*.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ...
 
+* [fix] add config/Zed/propel\*.yml to dockerignore
+
 ## 0.8.0
 
 * [fix] Detection of yves/zed domain 

--- a/shop/.dockerignore
+++ b/shop/.dockerignore
@@ -1,5 +1,6 @@
 # Ignore all, except the ones listed below
 **
+config/Zed/propel*.yml
 !docker/
 !assets/
 !public/

--- a/shop/.gitignore
+++ b/shop/.gitignore
@@ -73,6 +73,7 @@ npm-debug.log
 /src/Orm/Propel/*/Config/*
 /src/Orm/Propel/*/Schema
 /src/Orm/Propel/*/Sql
+/config/Zed/propel*.yml
 
 # tools
 composer.phar

--- a/shop/.gitignore
+++ b/shop/.gitignore
@@ -73,7 +73,6 @@ npm-debug.log
 /src/Orm/Propel/*/Config/*
 /src/Orm/Propel/*/Schema
 /src/Orm/Propel/*/Sql
-/config/Zed/propel*.yml
 
 # tools
 composer.phar


### PR DESCRIPTION
There is at least one command which makes use of the `config/Zed/propel.yml` config file provided by spryker/demoshop. As we would like one place to configure propel DB connection data, we have to drop this `propel.yml`, so even the command `console propel:pg-sql-compat` is using our settings from `config/Shared/*.php`.

This adds the `propel.yml` config file to the blacklists in `.dockerignore`